### PR TITLE
Use git dependencies in Gemfile for llt-* gems.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,3 +4,7 @@ source 'https://rubygems.org'
 gemspec
 
 gem 'coveralls', require: false
+
+gem 'llt-core', git: 'https://github.com/latin-language-toolkit/llt-core.git'
+gem 'llt-constants', git: 'https://github.com/latin-language-toolkit/llt-constants.git'
+gem 'llt-logger', git: 'https://github.com/latin-language-toolkit/llt-logger.git'

--- a/llt-segmenter.gemspec
+++ b/llt-segmenter.gemspec
@@ -18,6 +18,9 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
+  #spec.add_dependency "llt-core"
+  #spec.add_dependency "llt-constants"
+  #spec.add_dependency "llt-logger"
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec"

--- a/llt-segmenter.gemspec
+++ b/llt-segmenter.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |spec|
   spec.email         = ["latin.language.toolkit@gmail.com"]
   spec.description   = %q{Segments text into sentences}
   spec.summary       = %q{Segments text into sentences}
-  spec.homepage      = "latin-languge-toolkit.net"
+  spec.homepage      = "http://latin-language-toolkit.net"
   spec.license       = "MIT"
 
   spec.files         = `git ls-files`.split($/)


### PR DESCRIPTION
Later the published gems should be used. This is prepared in the
gemspec. For local development see [bundle_config](http://bundler.io/v1.3/bundle_config.html).

Please pull after llt-logger repository has been created.
