### PR TITLE
Documentation with usage examples.

### DIFF
--- a/doc/examples.md.erb
+++ b/doc/examples.md.erb
@@ -1,0 +1,5 @@
+# API Examples
+# Basic
+API is only responding when there's an application/xml accept header coming in.
+
+<%= example "http://localhost:9292/segment?text=Arma+virumque+cano.+Tantaene+animis+caelestibus+irae?" %>

--- a/doc/examples.md.erb
+++ b/doc/examples.md.erb
@@ -1,5 +1,20 @@
 # API Examples
+Example sentences:
+_Arma virumque cano. Tantaene animis caelestibus irae._
 # Basic
 API is only responding when there's an application/xml accept header coming in.
+The input can be provided as plain URL encoded text with the `text` parameter or 
+as URI (also URL encoded) with the `uri` parameter.
 
 <%= example "http://localhost:9292/segment?text=Arma+virumque+cano.+Tantaene+animis+caelestibus+irae?" %>
+<%= example "http://localhost:9292/segment?uri=http%3A%2F%2Fperseids.org%2F101ch2a.tb.txt" %>
+
+## Indexing
+`indexing`: `true` (default) or `false` => determines if @id is set in new sentences
+
+<%= example "http://localhost:9292/segment?text=Arma+virumque+cano.+Tantaene+animis+caelestibus+irae?&indexing=false" %>
+
+## Newline Boundary
+`newline_boundary`: `{number}` `0` (default) => count of consecutive newlines which are used as sentence boundary
+
+<%= example "http://localhost:9292/segment?text=Arma+virumque+cano%0ATantaene+animis+caelestibus+irae%3F&newline_boundary=2" %>

--- a/doc/update.rb
+++ b/doc/update.rb
@@ -1,0 +1,25 @@
+require 'erb'
+require 'net/http'
+require 'rexml/document'
+
+class Documenter
+  def example(url)
+    uri = URI(url)
+    response = Net::HTTP.get(uri)
+    doc = REXML::Document.new(response)
+    xml = ""
+    doc.write(xml, 1)
+    "[#{url}](#{url})\n\n```xml\n#{xml}\n```"
+  end
+
+  def write
+    directory = File.dirname(__FILE__)
+    template = File.open(directory + "/examples.md.erb", 'r').read
+    erb = ERB.new(template)
+    File.open(directory + "/examples.md", 'w+') do |file|
+      file.write(erb.result(binding))
+    end
+  end
+end
+
+Documenter.new.write


### PR DESCRIPTION
The examples are defined and described in an ERB template. Running ruby doc/update.rb uses a running server on localhost to generate the return values for the examples. The program can/should be moved to another repository (maybe as rake task). Another question is whether the examples should be part of the readme. At least the readme should link to the examples.
