### PR TITLE
Xml fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,4 @@ before_script:
   - "export JRUBY_OPTS=--2.0"
 rvm:
   - 2.0.0
-  - jruby-20mode
+  - jruby-1.7.8

--- a/lib/llt/segmenter.rb
+++ b/lib/llt/segmenter.rb
@@ -25,8 +25,10 @@ module LLT
     #
     # (?<=\s|^) can be just \b in MRI 2.0 and upwards
     AWB = ALL_ABBRS_PIPED.split('|').map { |abbr| "(?<=\\s|^)#{abbr}" }.join('|')
-    SENTENCE_CLOSER = /(?<!#{AWB})\.(?!\.)|[;\?!:]/
-    DIRECT_SPEECH_DELIMITER = /['"”]/
+    # the xml escaped characters cannot be refactored to something along
+    # &(?:amp|quot); - it's an invalid pattern in the look-behind
+    SENTENCE_CLOSER = /(?<!#{AWB})\.(?!\.)|[\?!:]|((?<!&amp|&quot|&apos|&lt|&gt);)/
+    DIRECT_SPEECH_DELIMITER = /['"”]|&(?:apos|quot);/
     TRAILERS = /\)|<\/.*?>/
 
     def segment(string, add_to: nil, **options)

--- a/spec/lib/llt/segmenter_spec.rb
+++ b/spec/lib/llt/segmenter_spec.rb
@@ -123,6 +123,29 @@ describe LLT::Segmenter do
       end
     end
 
+    context "with xml escaped characters" do
+      it "doesn't split when it shouldn't" do
+        txt = '&quot;text&quot; resumed. success.'
+        sentences = segmenter.segment(txt)
+        sentences.should have(2).item
+        sentences[1].to_s.should == 'success.'
+      end
+
+      it "acknowledges &quot; as potentially trailing delimiter" do
+        txt = '&quot;text.&quot; success.'
+        sentences = segmenter.segment(txt)
+        sentences.should have(2).item
+        sentences[1].to_s.should == 'success.'
+      end
+
+      it "acknowledges &apos; as potentially trailing delimiter" do
+        txt = '&apos;text.&apos; success.'
+        sentences = segmenter.segment(txt)
+        sentences.should have(2).item
+        sentences[1].to_s.should == 'success.'
+      end
+    end
+
     context "newline (\\n) handling" do
       it "works when in between" do
         txt = "Filia est.\nFilius est."

--- a/spec/lib/llt/segmenter_spec.rb
+++ b/spec/lib/llt/segmenter_spec.rb
@@ -89,8 +89,37 @@ describe LLT::Segmenter do
     context "with embedded xml" do
       it "doesn't break up before xml closing tags" do
         txt = '<grc> text.</grc>'
-        sentences = segmenter.segment(txt)
+        sentences = segmenter.segment(txt, xml: true)
         sentences.should have(1).item
+      end
+
+      it "doesn't break with punctuation in element names I" do
+        txt = '<grc.test>text.</grc.test>'
+        sentences = segmenter.segment(txt, xml: true)
+        sentences.should have(1).item
+      end
+
+      it "doesn't break with punctuation in element names II" do
+        txt = '<grc.test>text.</grc.test> text 2.'
+        sentences = segmenter.segment(txt, xml: true)
+        sentences.should have(2).items
+        sentences[0].to_s.should == '<grc.test>text.</grc.test>'
+        sentences[1].to_s.should == 'text 2.'
+      end
+
+      it "doesn't break with punctuation in element names III" do
+        txt = '<grc.test>text</grc.test> resumed. text 2.'
+        sentences = segmenter.segment(txt, xml: true)
+        sentences.should have(2).items
+        sentences[0].to_s.should == '<grc.test>text</grc.test> resumed.'
+        sentences[1].to_s.should == 'text 2.'
+      end
+
+      it "doesn't break with attribute values containing punctuation" do
+        txt = '<grc no="1.1"> text.</grc> text 2.'
+        sentences = segmenter.segment(txt, xml: true)
+        sentences.should have(2).items
+        sentences[1].to_s.should == 'text 2.'
       end
     end
 


### PR DESCRIPTION
- Handles punctuation characters inside of xml elements and attribute values
  - Only activated when the param xml is true, working basically the same as the tokenizer does that: xml mode is auto-detected by the `llt-core` api handlers, when the requested document contains an xml declaration
- Handles xml escape characters

Closes #11.
