### PR TITLE
Normalizing whitespace

### DIFF
--- a/lib/llt/segmenter.rb
+++ b/lib/llt/segmenter.rb
@@ -70,18 +70,7 @@ module LLT
       new_string = ''
       until scanner.eos?
         if match = scanner.scan_until(/"/)
-          if surrounded_by_whitespace?(scanner)
-            if direct_speech_open?
-              # eliminate the whitespace in front of "
-              new_string << match[0..-3] << '"'
-            else
-              new_string << match
-              # hop over the whitespace behind "
-              scanner.pos = scanner.pos + 1
-            end
-          else
-            new_string << match
-          end
+          new_string << normalized_match(scanner, match)
           toggle_direct_speech_status
         else
           new_string << scanner.rest
@@ -95,6 +84,21 @@ module LLT
       pos_before = scanner.pre_match[-1]
       pos_behind = scanner.post_match[0]
       pos_before == ' ' && (pos_behind == ' ' || pos_behind == nil) # end of string
+    end
+
+    def normalized_match(scanner, match)
+      if surrounded_by_whitespace?(scanner)
+        if direct_speech_open?
+          # eliminate the whitespace in front of "
+          match[0..-3] << '"'
+        else
+          # hop over the whitespace behind "
+          scanner.pos = scanner.pos + 1
+          match
+        end
+      else
+        match
+      end
     end
 
     def direct_speech_open?

--- a/spec/lib/llt/segmenter_spec.rb
+++ b/spec/lib/llt/segmenter_spec.rb
@@ -307,6 +307,18 @@ describe LLT::Segmenter do
       end
     end
 
+    context "with badly whitespaced direct speech delimiters" do
+      it "normalizes whitespace and knows to which sentence a \" belongs" do
+        txt = '"Marcus est. " Cicero est. " Iulius est. "'
+        sentences = segmenter.segment(txt)
+        #sentences.should have(3).items
+        sentences.map!(&:to_s)
+        sentences[0].should == '"Marcus est."'
+        sentences[1].should == 'Cicero est.'
+        sentences[2].should == '"Iulius est."'
+      end
+    end
+
     describe "takes an optional keyword argument add_to" do
       class ParagraphDummy
         attr_reader :sentences


### PR DESCRIPTION
For now only relevant when the incoming string is badly OCR'd and
direct speech delimiters as " have troubles to know where they belong,
because they are completely surrounded by whitespace.

Check out the spec to see exactly what we are talking about.
